### PR TITLE
Fix readme issue in setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Created by https://www.gitignore.io
+README.rst
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,39 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup, find_packages
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+from distutils.core import Command
+
+
+class MakeReadme(Command):
+    description = "Generates a README.rst version of README.md"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        try:
+            from pypandoc import convert
+            rst = convert('README.md', 'rst')
+            readme = open('README.rst', 'w+')
+            readme.write(rst)
+            readme.close()
+        except ImportError:
+            raise ImportWarning("Module pypandoc not found, could not convert Markdown to RST")
+
 
 req = open("requirements.txt")
-requirements = req.readlines()
+REQUIREMENTS = req.readlines()
+req.close()
+
+rm = open("README.rst")
+README = rm.readlines()
+rm.close()
 
 # Dynamically retrieve the version from the module
 version_string = __import__('zorg_gpio').__version__
@@ -17,14 +43,13 @@ setup(
     version=version_string,
     url="https://github.com/zorg/zorg-gpio",
     description="GPIO drivers for Zorg robots.",
-    setup_requires=['setuptools-markdown'],
-    long_description_markdown_filename='README.md',
-    author="Zorg Group",
-    author_email="gunthercx@gmail.com",
+    long_description=README,
+    maintainer="Zorg Group",
+    maintainer_email="gunthercx@gmail.com",
     packages=find_packages(),
     package_dir={"zorg_gpio": "zorg_gpio"},
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=REQUIREMENTS,
     license="MIT",
     zip_safe=True,
     platforms=["any"],
@@ -42,7 +67,11 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
     test_suite="tests",
-    tests_require=[]
+    tests_require=["mock"],
+    cmdclass={
+        "make_readme": MakeReadme,
+    }
 )

--- a/zorg_gpio/__init__.py
+++ b/zorg_gpio/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     'TemperatureSensor',
 ]
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'


### PR DESCRIPTION
Previously the setup file was using `setup_requires=['setuptools-markdown']` to generate a README.rst file to display on pypi.

This appears to fail when installing on a device without an internet connection.

This pull request is an experiment in adding a custom command `make_readme` to the setup.py file.
This would allow a README.rst to be generated from the current README.md before deploying to pypi, but it should not interfere with normal installations.
